### PR TITLE
Support opengear 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HowTo Install tailscale on OpenGear
 Short write-up on how to install tailscale on OpenGear.
 
-This is currently tested and used on the OpenGear Models `ACM7004-5-L` and `IM7216-2` with the OpenGear up to firmware Version `4.13.6` and tailscale version `1.62`.
+This is currently tested and used on the OpenGear Models `ACM7004-5-L` and `IM7216-2` with the OpenGear up to firmware Version `5.2.3` and tailscale version `1.86.2`.
 
 There MAY be some adjustments needed if deploying older tailscale binaries.
 

--- a/samples/tailscale-init-script
+++ b/samples/tailscale-init-script
@@ -1,5 +1,6 @@
 #!/bin/sh -eu
 
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 STATE="/etc/config/tailscale/tailscaled.state"
 SOCKET="/run/tailscale/tailscaled.sock"
 PID="/run/tailscale/tailscaled.pid"


### PR DESCRIPTION
Kia ora,

I have run through this process with Opengear OS 5.2.3 on an ACM7004-5-L, with Tailscale 1.86.2 and it works great.

The only change required was setting PATH at the top of the init script - the script seems to run without PATH set and it can't find iptables. Adding `export PATH=/usr/bin:/bin:/usr/sbin:/sbin` worked great.

This PR includes that change, and updates the docs to say which version is supported.